### PR TITLE
Miscellaneous updates

### DIFF
--- a/arnglld/Cargo.toml
+++ b/arnglld/Cargo.toml
@@ -16,3 +16,5 @@ cpal = "0.13"
 anyhow = "1.0"
 futures = {version = "0.3", features=["default", "thread-pool"]}
 stderrlog = "0.5"
+hex = "0.4"
+crc = "2.1"

--- a/arnglld/src/main.rs
+++ b/arnglld/src/main.rs
@@ -19,8 +19,15 @@
 // TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+use anyhow::format_err;
 use clap::Parser;
+use cpal::traits::{DeviceTrait, HostTrait};
+use futures::executor::{block_on, block_on_stream};
+use futures::prelude::*;
+use log::info;
 use hamaddr::HamAddr;
+use quick_dsp::bell202::{Bell202Receiver, Bell202Sender};
+use quick_dsp::filter::IteratorExt as _;
 
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
@@ -33,19 +40,152 @@ struct Opt {
     #[clap(short, long, parse(from_occurrences))]
     verbose: usize,
 
+    /// List audio devices
+    #[clap(long)]
+    list_devices: bool,
+
     #[clap(short, long)]
-    callsign: HamAddr,
+    callsign: Option<HamAddr>,
+
+    #[clap(long)]
+    input_audio_device: Option<String>,
+
+    #[clap(long)]
+    output_audio_device: Option<String>,
+}
+
+fn find_device<I: IntoIterator<Item = cpal::Device>>(
+    devices: I,
+    name: &str,
+) -> Option<cpal::Device> {
+    let lc_name = name.to_lowercase();
+    let mut devs = devices
+        .into_iter()
+        .filter_map(|d| Some((d.name().ok()?.to_lowercase(), d)))
+        .collect::<Vec<_>>();
+
+    // Try exact
+    if let Some((i, _)) = devs.iter().enumerate().find(|(_, (n, _))| n == &lc_name) {
+        return Some(devs.remove(i).1);
+    }
+
+    // Try prefix
+    if let Some((i, _)) = devs
+        .iter()
+        .enumerate()
+        .find(|(_, (n, _))| n.starts_with(&lc_name))
+    {
+        return Some(devs.remove(i).1);
+    }
+
+    // Any substring match
+    if let Some((i, _)) = devs
+        .iter()
+        .enumerate()
+        .find(|(_, (n, _))| n.contains(&lc_name))
+    {
+        return Some(devs.remove(i).1);
+    }
+
+    None
+}
+
+impl Opt {
+    fn get_output_device(&self) -> Result<cpal::Device, anyhow::Error> {
+        let host = cpal::default_host();
+
+        if let Some(name) = self.output_audio_device.as_ref() {
+            return find_device(host.output_devices()?, name.as_str())
+                .ok_or_else(|| format_err!("Cannot find output device matching {:?}", name));
+        }
+
+        host.default_output_device()
+            .ok_or_else(|| format_err!("no default output device"))
+    }
+
+    #[allow(dead_code)]
+    fn get_input_device(&self) -> Result<cpal::Device, anyhow::Error> {
+        let host = cpal::default_host();
+
+        if let Some(name) = self.input_audio_device.as_ref() {
+            return find_device(host.input_devices()?, name.as_str())
+                .ok_or_else(|| format_err!("Cannot find input device matching {:?}", name));
+        }
+
+        host.default_input_device()
+            .ok_or_else(|| format_err!("no default input device"))
+    }
+
+    #[allow(dead_code)]
+    fn get_packet_stream(&self) -> Result<Bell202Receiver, anyhow::Error> {
+        let device = self.get_input_device()?;
+        info!("Using input device {:?}", device.name());
+        let receiver = Bell202Receiver::new(&device)?;
+
+        Ok(receiver)
+    }
+
+    fn get_packet_sink(&self) -> Result<Bell202Sender, anyhow::Error> {
+        let device = self.get_output_device()?;
+        info!("Using output device {:?}", device.name());
+        let sender = Bell202Sender::new(&device)?;
+
+        Ok(sender)
+    }
 }
 
 fn main() {
     let opt = Opt::parse();
 
-    println!("Callsign: {}", opt.callsign);
-    println!("opt = {:?}", opt);
+    if opt.list_devices {
+        let host = cpal::default_host();
+        println!("Input Devices:");
+        for device in host.input_devices().expect("Unable to list input devices") {
+            if let Some(name) = device.name().ok() {
+                println!("\t{}", name);
+            }
+        }
+        println!("Output Devices:");
+        for device in host
+            .output_devices()
+            .expect("Unable to list output devices")
+        {
+            if let Some(name) = device.name().ok() {
+                println!("\t{}", name);
+            }
+        }
+        return;
+    }
 
     stderrlog::new()
         .quiet(opt.quiet)
         .verbosity(opt.verbose)
         .init()
         .unwrap();
+
+    println!("Callsign: {}", opt.callsign.expect("Missing callsign"));
+    println!("opt = {:?}", opt);
+
+    const X25: crc::Crc<u16> = crc::Crc::<u16>::new(&crc::CRC_16_IBM_SDLC);
+
+    let frame_string = format!(
+        "\x01\x00de {}: TEST: This is a test frame of ASCII text.",
+        opt.callsign.unwrap()
+    );
+    let frame = frame_string.bytes().append_crc(&X25);
+
+    let mut packet_sink = opt.get_packet_sink().unwrap();
+
+    println!("Sending test frame...");
+
+    // Play the test packet.
+    block_on(packet_sink.send(frame.collect())).unwrap();
+
+    println!("Listening for packets...");
+
+    let packet_stream = opt.get_packet_stream().unwrap();
+
+    for frame in block_on_stream(packet_stream) {
+        info!("Received: {:?}", hex::encode(frame));
+    }
 }

--- a/arnglld/src/main.rs
+++ b/arnglld/src/main.rs
@@ -24,9 +24,9 @@ use clap::Parser;
 use cpal::traits::{DeviceTrait, HostTrait};
 use futures::executor::{block_on, block_on_stream};
 use futures::prelude::*;
-use log::info;
 use hamaddr::HamAddr;
-use quick_dsp::bell202::{Bell202Receiver, Bell202Sender};
+use log::info;
+use quick_dsp::bell202::{Ax25Debug, Bell202Receiver, Bell202Sender};
 use quick_dsp::filter::IteratorExt as _;
 
 #[derive(Parser, Debug)]
@@ -186,6 +186,11 @@ fn main() {
     let packet_stream = opt.get_packet_stream().unwrap();
 
     for frame in block_on_stream(packet_stream) {
-        info!("Received: {:?}", hex::encode(frame));
+        let debug = Ax25Debug(&frame);
+        if debug.is_ax25() {
+            info!("Received AX25: {:?}", debug);
+        } else {
+            info!("Received: {:?}", hex::encode(frame));
+        }
     }
 }

--- a/hamaddr/src/ham_addr.rs
+++ b/hamaddr/src/ham_addr.rs
@@ -62,12 +62,28 @@ pub enum HamAddrType {
 
 impl HamAddr {
     /// Empty Address Constant.
+    ///
+    /// ```
+    /// # use hamaddr::HamAddr;
+    /// assert!(HamAddr::EMPTY.is_empty());
+    /// ```
     pub const EMPTY: HamAddr = HamAddr([0, 0, 0, 0, 0, 0, 0, 0]);
 
     /// Broadcast Address Constant.
+    ///
+    /// ```
+    /// # use hamaddr::HamAddr;
+    /// assert!(HamAddr::BROADCAST.is_broadcast());
+    /// ```
     pub const BROADCAST: HamAddr = HamAddr([0xFF, 0xFF, 0, 0, 0, 0, 0, 0]);
 
     /// Creates a new `HamAddr` from the given array of 8 bytes.
+    ///
+    /// ```
+    /// # use hamaddr::HamAddr;
+    /// let addr = HamAddr::new([0x46,0x71,0x6C,0xA0,0,0,0,0]);
+    /// assert_eq!(addr.to_string(), "KJ6QOH");
+    /// ```
     pub const fn new(octets: [u8; 8]) -> HamAddr {
         HamAddr(octets)
     }
@@ -75,6 +91,13 @@ impl HamAddr {
     /// Creates a new `HamAddr` from the given short address.
     ///
     /// Returns `None` if `shortaddr` is larger than `0x063F`.
+    ///
+    /// ```
+    /// # use std::num::NonZeroU16;
+    /// # use hamaddr::HamAddr;
+    /// let addr = HamAddr::try_from_shortaddr(NonZeroU16::new(48).unwrap()).unwrap();
+    /// assert_eq!(addr.shortaddr(), NonZeroU16::new(48));
+    /// ```
     pub const fn try_from_shortaddr(shortaddr: NonZeroU16) -> Option<HamAddr> {
         if shortaddr.get() > 0x063F {
             return None;
@@ -87,6 +110,12 @@ impl HamAddr {
     }
 
     /// Creates a `HamAddr` from a an array of four `u16` "chunks".
+    ///
+    /// ```
+    /// # use hamaddr::HamAddr;
+    /// let addr = HamAddr::from_chunks([0x4671,0x6CA0,0,0]);
+    /// assert_eq!(addr.to_string(), "KJ6QOH");
+    /// ```
     pub fn from_chunks(chunks: [u16; 4]) -> HamAddr {
         let mut ret = Self::EMPTY;
         let mut iter_mut = ret.0.iter_mut();
@@ -100,6 +129,12 @@ impl HamAddr {
     /// Tries to create a HamAddr from a byte slice.
     ///
     /// The byte slice must be either 2, 4, 6, or 8 bytes long.
+    ///
+    /// ```
+    /// # use hamaddr::HamAddr;
+    /// let addr = HamAddr::try_from_slice(&[0x46,0x71,0x6C,0xA0]).unwrap();
+    /// assert_eq!(addr.to_string(), "KJ6QOH");
+    /// ```
     pub fn try_from_slice(bytes: &[u8]) -> Result<HamAddr> {
         if (bytes.len() & 1) == 1 || bytes.len() > 8 {
             bail!("Invalid slice length");
@@ -110,6 +145,12 @@ impl HamAddr {
     }
 
     /// Tries to create a HamAddr from the given callsign string.
+    ///
+    /// ```
+    /// # use hamaddr::HamAddr;
+    /// let addr = HamAddr::try_from_callsign("kj6QOH").unwrap();
+    /// assert_eq!(addr.to_string(), "KJ6QOH");
+    /// ```
     pub fn try_from_callsign(callsign: &str) -> Result<HamAddr> {
         // Iterator type for converting a string into chunks.
         struct StrChunkIterator<T: Iterator<Item = char> + FusedIterator>(T);
@@ -153,11 +194,18 @@ impl HamAddr {
     }
 
     /// Tries to return the value of this `HamAddr` as a temporary short addreses.
+    ///
+    /// ```
+    /// # use std::num::NonZeroU16;
+    /// # use hamaddr::HamAddr;
+    /// let addr = HamAddr::try_from_shortaddr(NonZeroU16::new(48).unwrap()).unwrap();
+    /// assert_eq!(addr.shortaddr(), NonZeroU16::new(48));
+    /// ```
     pub const fn shortaddr(&self) -> Option<NonZeroU16> {
         // We use match instead of == so we can stay const.
         match self.get_type() {
             HamAddrType::Short => NonZeroU16::new(self.chunk(0)),
-            _ => None
+            _ => None,
         }
     }
 

--- a/quick-dsp/src/bell202/receiver.rs
+++ b/quick-dsp/src/bell202/receiver.rs
@@ -60,7 +60,13 @@ impl Bell202Receiver {
                 if let Ok(ret) = Self::new_with_config(device, &supported_config) {
                     Ok(ret)
                 } else {
-                    Err(err)
+                    // Last try.
+                    supported_config.sample_rate = SampleRate(48000);
+                    if let Ok(ret) = Self::new_with_config(device, &supported_config) {
+                        Ok(ret)
+                    } else {
+                        Err(err)
+                    }
                 }
             }
         }
@@ -70,7 +76,7 @@ impl Bell202Receiver {
         device: &cpal::Device,
         supported_config: &StreamConfig,
     ) -> Result<Bell202Receiver, Error> {
-        debug!("supported_config: {:?}", supported_config);
+        debug!("Receiver stream config: {:?}", supported_config);
         let mut downsampler =
             Downsampler::<f32>::new(supported_config.sample_rate.0, BELL202_OPTIMAL_SAMPLE_RATE);
 

--- a/quick-dsp/src/bell202/sender.rs
+++ b/quick-dsp/src/bell202/sender.rs
@@ -25,6 +25,7 @@ use cpal::traits::*;
 use cpal::*;
 use futures::channel::mpsc;
 use futures::SinkExt;
+use log::debug;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
@@ -54,6 +55,8 @@ impl Bell202Sender {
         let mut encoder = bell_202_encode(vec![].into_iter(), sample_rate, 0.75);
 
         let (sendframe_sender, mut sendframe_receiver) = mpsc::channel::<Vec<u8>>(3);
+
+        debug!("Sender stream config: {:?}", supported_config);
 
         let output_audio_stream = device.build_output_stream(
             &supported_config,


### PR DESCRIPTION
* 510b614 hamaddr: Add some examples to the documentation.
* 752b7d9 quick_dsp: Add an AX25 packet debug wrapper for displaying AX25 packets.
* dd4f961 quick_dsp: Log the steam config and add work-around for `cpal` bug.
* 6e96e8e arnglld: Added audio device selection options.
* 5a7ba0c quick_dsp: Added `CrcAppendIter` for appending CRCs.