### PR TITLE
Lots of miscellaneous changes

### DIFF
--- a/arnglld/src/main.rs
+++ b/arnglld/src/main.rs
@@ -64,7 +64,11 @@ fn find_device<I: IntoIterator<Item = cpal::Device>>(
         .filter_map(|d| Some((d.name().ok()?.to_lowercase(), d)))
         .collect::<Vec<_>>();
 
-    info!("Looking for {:?} in {:#?}", name, devs.iter().map(|x|x.0.as_str()).collect::<Vec<_>>());
+    info!(
+        "Looking for {:?} in {:#?}",
+        name,
+        devs.iter().map(|x| x.0.as_str()).collect::<Vec<_>>()
+    );
 
     // Try exact
     if let Some((i, _)) = devs.iter().enumerate().find(|(_, (n, _))| n == &lc_name) {
@@ -72,9 +76,9 @@ fn find_device<I: IntoIterator<Item = cpal::Device>>(
     }
 
     // Try integer.
-    if let Some(i) = usize::from_str_radix(name,10).ok() {
+    if let Some(i) = usize::from_str_radix(name, 10).ok() {
         if i != 0 && i - 1 < devs.len() {
-            return Some(devs.remove(i-1).1);
+            return Some(devs.remove(i - 1).1);
         }
     }
 
@@ -147,14 +151,34 @@ fn main() {
     {
         // Work around for weird cpal issues.
         let host = cpal::default_host();
-        let _input_device_names = host.input_devices().expect("Unable to list input devices").into_iter().filter_map(|x|x.name().ok()).collect::<Vec<_>>();
-        let _output_device_names = host.output_devices().expect("Unable to list input devices").into_iter().filter_map(|x|x.name().ok()).collect::<Vec<_>>();
+        let _input_device_names = host
+            .input_devices()
+            .expect("Unable to list input devices")
+            .into_iter()
+            .filter_map(|x| x.name().ok())
+            .collect::<Vec<_>>();
+        let _output_device_names = host
+            .output_devices()
+            .expect("Unable to list input devices")
+            .into_iter()
+            .filter_map(|x| x.name().ok())
+            .collect::<Vec<_>>();
     }
 
     if opt.list_devices {
         let host = cpal::default_host();
-        let input_device_names = host.input_devices().expect("Unable to list input devices").into_iter().filter_map(|x|x.name().ok()).collect::<Vec<_>>();
-        let output_device_names = host.output_devices().expect("Unable to list input devices").into_iter().filter_map(|x|x.name().ok()).collect::<Vec<_>>();
+        let input_device_names = host
+            .input_devices()
+            .expect("Unable to list input devices")
+            .into_iter()
+            .filter_map(|x| x.name().ok())
+            .collect::<Vec<_>>();
+        let output_device_names = host
+            .output_devices()
+            .expect("Unable to list input devices")
+            .into_iter()
+            .filter_map(|x| x.name().ok())
+            .collect::<Vec<_>>();
         println!("Input Devices: {:#?}", input_device_names);
         println!("Output Devices: {:#?}", output_device_names);
         return;

--- a/arnglld/src/main.rs
+++ b/arnglld/src/main.rs
@@ -181,8 +181,9 @@ fn main() {
 
     println!("Sending test frame...");
 
+    let frame = frame.collect::<Vec<_>>();
     // Play the test packet.
-    block_on(packet_sink.send(frame.collect())).unwrap();
+    block_on(packet_sink.send(frame.clone())).unwrap();
 
     println!("Listening for packets...");
 

--- a/hamaddr/src/eui.rs
+++ b/hamaddr/src/eui.rs
@@ -57,6 +57,17 @@ impl Eui64 {
     pub const fn new(addr: [u8; 8]) -> Eui64 {
         Eui64(addr)
     }
+
+    pub fn try_to_eui48(self) -> Option<Eui48> {
+        if self.0[3] == 0xFF && self.0[4] == 0xFE {
+            let mut bytes = [0; 6];
+            bytes[..3].copy_from_slice(&self.0[..3]);
+            bytes[3..6].copy_from_slice(&self.0[5..8]);
+            Some(Eui48(bytes))
+        } else {
+            None
+        }
+    }
 }
 
 /// Formats an Eui64 for display.
@@ -80,6 +91,12 @@ impl From<&Eui48> for Eui64 {
         bytes[4] = 0xFE; // See RFC 4291, App A.
         bytes[5..].copy_from_slice(&eui48.0[3..]);
         Eui64(bytes)
+    }
+}
+
+impl From<Eui48> for Eui64 {
+    fn from(eui48: Eui48) -> Self {
+        Eui64::from(&eui48)
     }
 }
 

--- a/hamaddr/src/lib.rs
+++ b/hamaddr/src/lib.rs
@@ -68,6 +68,46 @@ mod ham_addr_tests {
     }
 
     #[test]
+    fn test_ham_addr_to_eui64_12_char_hack() {
+        let addr = "KJ6QOH-23".parse::<HamAddr>().unwrap();
+        let eui64: Eui64 = addr.try_into().unwrap();
+        assert_eq!(eui64.to_string(), "22:46:71:ff:fe:6c:a0:f2");
+        assert_eq!(HamAddr::try_from(eui64).unwrap(), addr);
+
+        let eui64 = Eui64([0x02, 0x46, 0x71, 0x6C, 0xA0, 0xF2, 0x20, 0x00]);
+        assert_eq!(HamAddr::try_from(eui64).unwrap().to_string(), "KJ6QOH-2X");
+
+        let addr = "KJ6QOH-99".parse::<HamAddr>().unwrap();
+        let eui64: Eui64 = addr.try_into().unwrap();
+        assert_eq!(eui64.to_string(), "02:46:71:6c:a0:f3:44:00");
+        assert_eq!(HamAddr::try_from(eui64).unwrap(), addr);
+    }
+
+    #[test]
+    fn test_ham_addr_to_eui48_9_char_hack() {
+        let addr = "KJ6QOH-23".parse::<HamAddr>().unwrap();
+        let eui48: Eui48 = addr.try_into().unwrap();
+        assert_eq!(eui48.to_string(), "22:46:71:6c:a0:f2");
+        assert_eq!(HamAddr::try_from(eui48).unwrap(), addr);
+
+        let addr = "KJ6QOH-2X".parse::<HamAddr>().unwrap();
+        let eui48_result = Eui48::try_from(addr);
+        assert!(
+            eui48_result.is_err(),
+            "KJ6QOH-2X parsed to EUI48: {}",
+            eui48_result.unwrap()
+        );
+
+        let addr = "KJ6QOH-99".parse::<HamAddr>().unwrap();
+        let eui48_result = Eui48::try_from(addr);
+        assert!(
+            eui48_result.is_err(),
+            "KJ6QOH-99 parsed to EUI48: {}",
+            eui48_result.unwrap()
+        );
+    }
+
+    #[test]
     fn test_ham_addr_to_eui64() {
         let addr = "KZ2X-1".parse::<HamAddr>().unwrap();
         let eui64: Eui64 = addr.try_into().unwrap();

--- a/quick-dsp/Cargo.toml
+++ b/quick-dsp/Cargo.toml
@@ -14,6 +14,8 @@ crc = "2.1"
 cpal = "0.13"
 anyhow = "1.0"
 stderrlog = "0.5"
+async-timer = "0.7"
+rand = "0.8"
 
 [dev-dependencies]
 wav = "1.0"

--- a/quick-dsp/src/bell202/mod.rs
+++ b/quick-dsp/src/bell202/mod.rs
@@ -30,7 +30,7 @@ use std::fmt::{Debug, Formatter};
 pub const BELL202_RATE: u32 = 1200;
 pub const BELL202_MARK: u32 = 1200;
 pub const BELL202_SPACE: u32 = 2200;
-pub const BELL202_OPTIMAL_SAMPLE_RATE: u32 = (BELL202_MARK+BELL202_SPACE)*2+349;
+pub const BELL202_OPTIMAL_SAMPLE_RATE: u32 = (BELL202_MARK + BELL202_SPACE) * 2 + 349;
 
 /// Bell 202 decoder.
 ///

--- a/quick-dsp/src/bell202/receiver.rs
+++ b/quick-dsp/src/bell202/receiver.rs
@@ -20,7 +20,7 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 use super::{bell_202_decoder, BELL202_OPTIMAL_SAMPLE_RATE};
-use crate::filter::{Downsampler, OneToOne};
+use crate::filter::{Downsampler, Filter};
 use anyhow::{Context as _, Error, Result};
 use cpal::traits::*;
 use cpal::*;

--- a/quick-dsp/src/bell202/sender.rs
+++ b/quick-dsp/src/bell202/sender.rs
@@ -19,19 +19,28 @@
 // TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+use std::cell::Cell;
+use std::future::Future;
 use super::bell_202_encode;
-use anyhow::{Context as _, Error, Result};
+use anyhow::{Context as _, Error, format_err, Result};
 use cpal::traits::*;
 use cpal::*;
 use futures::channel::mpsc;
 use futures::SinkExt;
 use log::debug;
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::task::{Context, Poll, Waker};
+use futures::task::noop_waker;
+use async_timer::oneshot::{Oneshot, Timer};
+use rand::Rng;
 
 pub struct Bell202Sender {
     output_audio_stream: cpal::Stream,
     sendframe_sender: mpsc::Sender<Vec<u8>>,
+    is_channel_clear: AtomicBool,
+    channel_clear_waker: Cell<Waker>,
+    cca_backoff_timer: Option<Timer>,
 }
 
 impl Bell202Sender {
@@ -76,9 +85,11 @@ impl Bell202Sender {
     ) -> Result<Bell202Sender, Error> {
         let sample_rate = supported_config.sample_rate.0;
 
-        let mut encoder = bell_202_encode(vec![].into_iter(), sample_rate, 0.75);
+        // We are just using this to make sure we get the type right
+        // for the output func. It should play as silence.
+        let mut encoder = bell_202_encode::<f32, _>(vec![].into_iter(), sample_rate, 0.0);
 
-        let (sendframe_sender, mut sendframe_receiver) = mpsc::channel::<Vec<u8>>(3);
+        let (sendframe_sender, mut sendframe_receiver) = mpsc::channel::<Vec<u8>>(1);
 
         debug!("Sender stream config: {:?}", supported_config);
 
@@ -90,7 +101,7 @@ impl Bell202Sender {
                         *sample = value;
                     } else if let Ok(Some(vec)) = sendframe_receiver.try_next() {
                         // Set up the next frame.
-                        encoder = bell_202_encode::<f32, _>(vec.into_iter(), sample_rate, 0.75);
+                        encoder = bell_202_encode(vec.into_iter(), sample_rate, 0.75);
                         *sample = encoder.next().unwrap();
                     } else {
                         *sample = 0.0;
@@ -108,7 +119,18 @@ impl Bell202Sender {
         Ok(Bell202Sender {
             output_audio_stream,
             sendframe_sender,
+            is_channel_clear: AtomicBool::new(true),
+            channel_clear_waker: Cell::new(noop_waker()),
+            cca_backoff_timer: None,
         })
+    }
+
+    /// Sets channel clear indicator. This should be set to false
+    /// when there is a signal on the channel, true if no signal is detected.
+    pub fn set_channel_clear(&self, is_channel_clear: bool) {
+        debug!("CCA: is_channel_clear={:?}", is_channel_clear);
+        self.is_channel_clear.store(is_channel_clear, Ordering::Relaxed);
+        self.channel_clear_waker.replace(noop_waker()).wake()
     }
 
     pub fn pause(&mut self) -> Result<(), Error> {
@@ -129,15 +151,33 @@ impl futures::sink::Sink<Vec<u8>> for Bell202Sender {
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<std::result::Result<(), Self::Error>> {
-        self.sendframe_sender
-            .poll_ready_unpin(cx)
-            .map_err(anyhow::Error::from)
+        if let Some(timer) = self.cca_backoff_timer.as_mut() {
+            if Pin::new(timer).poll(cx).is_pending() {
+                return Poll::Pending;
+            }
+        }
+
+        self.cca_backoff_timer = None;
+
+        if self.is_channel_clear.load(Ordering::Relaxed) {
+            self.sendframe_sender
+                .poll_ready_unpin(cx)
+                .map_err(anyhow::Error::from)
+        } else {
+            self.cca_backoff_timer = Some(Timer::new(std::time::Duration::from_millis(rand::thread_rng().gen_range(5..50))));
+            self.channel_clear_waker.replace(cx.waker().clone());
+            Poll::Pending
+        }
     }
 
     fn start_send(mut self: Pin<&mut Self>, item: Vec<u8>) -> std::result::Result<(), Self::Error> {
-        self.sendframe_sender
-            .start_send_unpin(item)
-            .map_err(anyhow::Error::from)
+        if self.is_channel_clear.load(Ordering::Relaxed) {
+            self.sendframe_sender
+                .start_send_unpin(item)
+                .map_err(anyhow::Error::from)
+        } else {
+            Err(format_err!("Channel not clear"))
+        }
     }
 
     fn poll_flush(

--- a/quick-dsp/src/bell202/sender.rs
+++ b/quick-dsp/src/bell202/sender.rs
@@ -50,6 +50,30 @@ impl Bell202Sender {
         // We only care about a single channel.
         supported_config.channels = 1;
 
+        match Self::new_with_config(device, &supported_config) {
+            Ok(ret) => Ok(ret),
+            Err(err) => {
+                // Try a different sample rate.
+                supported_config.sample_rate = SampleRate(11025);
+                if let Ok(ret) = Self::new_with_config(device, &supported_config) {
+                    Ok(ret)
+                } else {
+                    // Last try.
+                    supported_config.sample_rate = SampleRate(8000);
+                    if let Ok(ret) = Self::new_with_config(device, &supported_config) {
+                        Ok(ret)
+                    } else {
+                        Err(err)
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn new_with_config(
+        device: &cpal::Device,
+        supported_config: &StreamConfig,
+    ) -> Result<Bell202Sender, Error> {
         let sample_rate = supported_config.sample_rate.0;
 
         let mut encoder = bell_202_encode(vec![].into_iter(), sample_rate, 0.75);

--- a/quick-dsp/src/filter/boxfilter.rs
+++ b/quick-dsp/src/filter/boxfilter.rs
@@ -21,8 +21,8 @@
 
 //! FIR Filter.
 
-use std::cmp::Ordering;
 use super::*;
+use std::cmp::Ordering;
 
 #[derive(Clone, Debug)]
 pub struct FilterBox<T>(CircularQueue<T>);
@@ -51,44 +51,43 @@ impl<T: Real> Filter<T> for FilterBox<T> {
     }
 }
 
-
-
-
 #[derive(Clone, Debug)]
-pub struct FilterMedian<T, const N: usize>([T;N]);
+pub struct FilterMedian<T, const N: usize>([T; N]);
 
-impl<T, const N: usize> Delay for FilterMedian<T,N> {
+impl<T, const N: usize> Delay for FilterMedian<T, N> {
     fn delay(&self) -> usize {
-        N/2
+        N / 2
     }
 }
 
-impl<T:Default, const N: usize> Default for FilterMedian<T,N>
-    where [T;N]: Default
+impl<T: Default, const N: usize> Default for FilterMedian<T, N>
+where
+    [T; N]: Default,
 {
     fn default() -> Self {
         Self(Default::default())
     }
 }
 
-impl<T: Default, const N: usize> FilterMedian<T,N>
-    where [T;N]: Default
+impl<T: Default, const N: usize> FilterMedian<T, N>
+where
+    [T; N]: Default,
 {
     pub fn new() -> Self {
         Default::default()
     }
 }
 
-impl<T: Default + Copy + PartialOrd, const N: usize> Filter<T> for FilterMedian<T,N> {
+impl<T: Default + Copy + PartialOrd, const N: usize> Filter<T> for FilterMedian<T, N> {
     type Output = T;
 
     fn filter(&mut self, sample: T) -> T {
         // Not super fast, but it works.
-        self.0.copy_within(0..N-1,1);
+        self.0.copy_within(0..N - 1, 1);
         self.0[0] = sample;
         let mut x = self.0.clone();
         x.sort_unstable_by(|a, b| a.partial_cmp(b).unwrap_or(Ordering::Equal));
-        x[N/2]
+        x[N / 2]
     }
 }
 

--- a/quick-dsp/src/filter/decimator.rs
+++ b/quick-dsp/src/filter/decimator.rs
@@ -46,7 +46,7 @@ impl Default for Decimator<f32, f32> {
     }
 }
 
-impl OneToOne<f32> for Decimator<f32, f32> {
+impl Filter<f32> for Decimator<f32, f32> {
     type Output = f32;
 
     fn filter(&mut self, sample: f32) -> Self::Output {
@@ -69,7 +69,7 @@ impl<F: Real> Decimator<F, i8> {
         }
     }
 }
-impl<F: Real> OneToOne<F> for Decimator<F, i8> {
+impl<F: Real> Filter<F> for Decimator<F, i8> {
     type Output = i8;
 
     fn filter(&mut self, sample: F) -> Self::Output {
@@ -102,7 +102,7 @@ impl<F: Real> Decimator<F, u8> {
         }
     }
 }
-impl<F: Real> OneToOne<F> for Decimator<F, u8> {
+impl<F: Real> Filter<F> for Decimator<F, u8> {
     type Output = u8;
 
     fn filter(&mut self, sample: F) -> Self::Output {
@@ -135,7 +135,7 @@ impl<F: Real> Decimator<F, i16> {
         }
     }
 }
-impl<F: Real> OneToOne<F> for Decimator<F, i16> {
+impl<F: Real> Filter<F> for Decimator<F, i16> {
     type Output = i16;
 
     fn filter(&mut self, sample: F) -> Self::Output {
@@ -168,7 +168,7 @@ impl<F: Real> Decimator<F, u16> {
         }
     }
 }
-impl<F: Real> OneToOne<F> for Decimator<F, u16> {
+impl<F: Real> Filter<F> for Decimator<F, u16> {
     type Output = u16;
 
     fn filter(&mut self, sample: F) -> Self::Output {

--- a/quick-dsp/src/filter/discriminator.rs
+++ b/quick-dsp/src/filter/discriminator.rs
@@ -34,11 +34,10 @@ impl<T> Delay for QamDiscriminatorFast<T> {
     }
 }
 
-impl<T:Real> Filter<(T, T)> for QamDiscriminatorFast<T>
-{
+impl<T: Real> Filter<(T, T)> for QamDiscriminatorFast<T> {
     type Output = (T, T); // (angle, magnitude_squared)
 
-    fn filter(&mut self, sample: (T,T)) -> Self::Output {
+    fn filter(&mut self, sample: (T, T)) -> Self::Output {
         if !sample.0.is_finite() || !sample.1.is_finite() {
             return (T::NAN, T::NAN);
         }
@@ -59,16 +58,11 @@ impl<T:Real> Filter<(T, T)> for QamDiscriminatorFast<T>
 
         let carrier: T = T::FORTH;
         let inv_carrier: T = T::ONE / carrier;
-        let neg_recip_tau:T = -inv_carrier / T::TAU;
+        let neg_recip_tau: T = -inv_carrier / T::TAU;
 
-        (
-            (self.last * neg_recip_tau + T::ONE) * carrier,
-            mag_sq,
-        )
+        ((self.last * neg_recip_tau + T::ONE) * carrier, mag_sq)
     }
 }
-
-
 
 #[derive(Debug, Clone, Default)]
 pub struct QamDiscriminatorAccurate<T> {
@@ -82,11 +76,10 @@ impl<T> Delay for QamDiscriminatorAccurate<T> {
     }
 }
 
-impl<T:Real> Filter<(T, T)> for QamDiscriminatorAccurate<T>
-{
+impl<T: Real> Filter<(T, T)> for QamDiscriminatorAccurate<T> {
     type Output = (T, T); // (angle, magnitude_squared)
 
-    fn filter(&mut self, sample: (T,T)) -> Self::Output {
+    fn filter(&mut self, sample: (T, T)) -> Self::Output {
         if !sample.0.is_finite() || !sample.1.is_finite() {
             return (T::NAN, T::NAN);
         }
@@ -113,12 +106,9 @@ impl<T:Real> Filter<(T, T)> for QamDiscriminatorAccurate<T>
 
         let carrier: T = T::FORTH;
         let inv_carrier: T = T::ONE / carrier;
-        let neg_recip_tau:T = -inv_carrier / T::TAU;
+        let neg_recip_tau: T = -inv_carrier / T::TAU;
 
-        (
-            (self.last * neg_recip_tau + T::ONE) * carrier,
-            mag_sq,
-        )
+        ((self.last * neg_recip_tau + T::ONE) * carrier, mag_sq)
     }
 }
 
@@ -126,8 +116,8 @@ impl<T:Real> Filter<(T, T)> for QamDiscriminatorAccurate<T>
 ///
 /// Output is (angle, magnitude_squared)
 #[derive(Clone, Debug)]
-pub struct Discriminator<T, FIQ=(), FOUT=()> {
-    qam: QamSplitFixed<T,FIQ>,
+pub struct Discriminator<T, FIQ = (), FOUT = ()> {
+    qam: QamSplitFixed<T, FIQ>,
     disc: QamDiscriminatorAccurate<T>,
     filter_out: FOUT,
 }
@@ -165,7 +155,8 @@ impl<T: Real, FIQ, FOUT> Discriminator<T, FIQ, FOUT> {
     }
 }
 
-impl<T, FIQ: Filter<T, Output = T>, FOUT: Filter<T, Output = T>> Filter<T> for Discriminator<T, FIQ, FOUT>
+impl<T, FIQ: Filter<T, Output = T>, FOUT: Filter<T, Output = T>> Filter<T>
+    for Discriminator<T, FIQ, FOUT>
 where
     T: Real,
 {

--- a/quick-dsp/src/filter/fm_mod.rs
+++ b/quick-dsp/src/filter/fm_mod.rs
@@ -37,7 +37,7 @@ impl<T: Real> FmMod<T> {
     }
 }
 
-impl<T: Real> OneToOne<T> for FmMod<T> {
+impl<T: Real> Filter<T> for FmMod<T> {
     type Output = T;
 
     fn filter(&mut self, sample: T) -> Self::Output {

--- a/quick-dsp/src/filter/fsk_demod.rs
+++ b/quick-dsp/src/filter/fsk_demod.rs
@@ -39,7 +39,7 @@ impl<T: Real> FskDemod<T> {
     }
 }
 
-impl<T: Real> OneToOne<(T, T)> for FskDemod<T> {
+impl<T: Real> Filter<(T, T)> for FskDemod<T> {
     type Output = Option<bool>;
 
     fn filter(&mut self, sample: (T, T)) -> Self::Output {
@@ -66,7 +66,7 @@ mod tests {
 
     #[test]
     fn fsk_demod_f32() {
-        let disc = Discriminator::<f32, ()>::digital_default();
+        let disc = Discriminator::<f32, (), ()>::digital_default();
         let mut disc = disc.chain(FskDemod::new(0.2, 0.3));
 
         let mut modulator = FmMod::<f32>::new(1.0);

--- a/quick-dsp/src/filter/hdlc.rs
+++ b/quick-dsp/src/filter/hdlc.rs
@@ -152,7 +152,7 @@ impl Reset for HdlcDecode {
     }
 }
 
-impl OneToOne<Option<bool>> for HdlcDecode {
+impl Filter<Option<bool>> for HdlcDecode {
     type Output = Option<FrameSignal>;
 
     fn filter(&mut self, sample: Option<bool>) -> Self::Output {
@@ -169,7 +169,7 @@ impl OneToOne<Option<bool>> for HdlcDecode {
     }
 }
 
-impl OneToOne<bool> for HdlcDecode {
+impl Filter<bool> for HdlcDecode {
     type Output = Option<FrameSignal>;
 
     fn filter(&mut self, sample: bool) -> Self::Output {
@@ -239,7 +239,7 @@ impl Delay for FrameCollector {
     }
 }
 
-impl OneToOne<Option<FrameSignal>> for FrameCollector {
+impl Filter<Option<FrameSignal>> for FrameCollector {
     type Output = Option<Vec<u8>>;
 
     fn filter(&mut self, sample: Option<FrameSignal>) -> Self::Output {
@@ -294,7 +294,7 @@ impl Reset for BitSampler {
     }
 }
 
-impl OneToOne<Option<bool>> for BitSampler {
+impl Filter<Option<bool>> for BitSampler {
     type Output = Option<bool>;
 
     fn filter(&mut self, sample: Option<bool>) -> Self::Output {

--- a/quick-dsp/src/filter/iir.rs
+++ b/quick-dsp/src/filter/iir.rs
@@ -37,7 +37,7 @@ fn calc_chebyshev(
     //rp = -cos(M_PI/(poles*2.0) + (p-1.0)*M_PI/poles);
     //ip = sin(M_PI/(poles*2.0) + (p-1.0)*M_PI/poles);
     let mut rp = -(f64::PI / f64::from_usize(poles * 2)
-        +  f64::from_usize(p - 1) * f64::PI / f64::from_usize(poles))
+        + f64::from_usize(p - 1) * f64::PI / f64::from_usize(poles))
     .cos();
     let mut ip = (f64::PI / f64::from_usize(poles * 2)
         + f64::from_usize(p - 1) * f64::PI / f64::from_usize(poles))
@@ -206,13 +206,8 @@ impl<T: Real, const TAPS: usize> ChebyshevKernel<T, TAPS> {
 }
 
 impl<T: Real, const TAPS: usize> ChebyshevKernel<T, TAPS> {
-    fn chebyshev(
-        cutoff1: f64,
-        cutoff2: f64,
-        ripple: f64,
-        filter_type: FilterType,
-    ) -> Self {
-        let poles = (TAPS-1) as usize;
+    fn chebyshev(cutoff1: f64, cutoff2: f64, ripple: f64, filter_type: FilterType) -> Self {
+        let poles = (TAPS - 1) as usize;
         let mut ret = Self {
             a: [T::ZERO; TAPS],
             b: [T::ZERO; TAPS],
@@ -233,8 +228,16 @@ impl<T: Real, const TAPS: usize> ChebyshevKernel<T, TAPS> {
                 tb.insert(0, T::ZERO);
 
                 let (a_x, b_x) = calc_chebyshev(poles, p, cutoff1, cutoff2, ripple, filter_type);
-                let a_x = [T::from_f64(a_x[0]),T::from_f64(a_x[1]),T::from_f64(a_x[2])];
-                let b_x = [T::from_f64(b_x[0]),T::from_f64(b_x[1]),T::from_f64(b_x[2])];
+                let a_x = [
+                    T::from_f64(a_x[0]),
+                    T::from_f64(a_x[1]),
+                    T::from_f64(a_x[2]),
+                ];
+                let b_x = [
+                    T::from_f64(b_x[0]),
+                    T::from_f64(b_x[1]),
+                    T::from_f64(b_x[2]),
+                ];
                 for (i, (a, b)) in ret.a.iter_mut().zip(ret.b.iter_mut()).enumerate() {
                     *a = a_x[0] * ta[i + 2] + a_x[1] * ta[i + 1] + a_x[2] * ta[i + 0];
                     *b = tb[i + 2] - b_x[1] * tb[i + 1] - b_x[2] * tb[i + 0];
@@ -276,7 +279,9 @@ impl<T: Real, const TAPS: usize> ChebyshevKernel<T, TAPS> {
     }
 }
 
-impl<T: Real, const TAPS: usize> From<ChebyshevKernel<T, TAPS>> for FilterIir<ChebyshevKernel<T, TAPS>> {
+impl<T: Real, const TAPS: usize> From<ChebyshevKernel<T, TAPS>>
+    for FilterIir<ChebyshevKernel<T, TAPS>>
+{
     fn from(kernel: ChebyshevKernel<T, TAPS>) -> Self {
         FilterIir::from_kernel(kernel)
     }
@@ -395,7 +400,7 @@ mod tests {
 
     #[test]
     fn filter_iir_dataset_test3() {
-        let filter = FilterChebyshev::<f64,5>::low_pass(0.25, 0.5);
+        let filter = FilterChebyshev::<f64, 5>::low_pass(0.25, 0.5);
         println!("filter_iir_dataset_test3: {:#?}", filter);
 
         assert!((filter.kernel.a()[0] - 0.07015301).abs() < 0.00001);
@@ -412,7 +417,7 @@ mod tests {
 
     #[test]
     fn filter_iir_low_pass_histogram_2_pole() {
-        let kernel = ChebyshevKernel::<_,3>::low_pass(0.25f64, 0.5f64);
+        let kernel = ChebyshevKernel::<_, 3>::low_pass(0.25f64, 0.5f64);
 
         let fresponse = (0..50)
             .into_iter()
@@ -429,7 +434,7 @@ mod tests {
 
     #[test]
     fn filter_iir_low_pass_histogram_4_pole() {
-        let kernel = ChebyshevKernel::<_,5>::low_pass(0.25f64, 0.5f64);
+        let kernel = ChebyshevKernel::<_, 5>::low_pass(0.25f64, 0.5f64);
 
         let fresponse = (0..50)
             .into_iter()
@@ -446,7 +451,7 @@ mod tests {
 
     #[test]
     fn filter_iir_low_pass_histogram_6_pole() {
-        let kernel = ChebyshevKernel::<_,7>::low_pass(0.25f64, 0.5f64);
+        let kernel = ChebyshevKernel::<_, 7>::low_pass(0.25f64, 0.5f64);
 
         let fresponse = (0..50)
             .into_iter()
@@ -463,7 +468,7 @@ mod tests {
 
     #[test]
     fn filter_iir_high_pass_histogram_2_pole() {
-        let kernel = ChebyshevKernel::<_,3>::high_pass(0.25f64, 0.5f64);
+        let kernel = ChebyshevKernel::<_, 3>::high_pass(0.25f64, 0.5f64);
 
         let fresponse = (1..=50)
             .into_iter()
@@ -480,7 +485,7 @@ mod tests {
 
     #[test]
     fn filter_iir_high_pass_histogram_4_pole() {
-        let kernel = ChebyshevKernel::<_,5>::high_pass(0.25f64, 0.5f64);
+        let kernel = ChebyshevKernel::<_, 5>::high_pass(0.25f64, 0.5f64);
 
         let fresponse = (1..=50)
             .into_iter()
@@ -497,7 +502,7 @@ mod tests {
 
     #[test]
     fn filter_iir_high_pass_histogram_6_pole() {
-        let kernel = ChebyshevKernel::<_,7>::high_pass(0.25f64, 0.5f64);
+        let kernel = ChebyshevKernel::<_, 7>::high_pass(0.25f64, 0.5f64);
 
         let fresponse = (1..=50)
             .into_iter()
@@ -514,11 +519,11 @@ mod tests {
 
     #[test]
     fn filter_iir_low_pass_performance_2pole() {
-        let gain_h = calc_gain(FilterChebyshev::<_,3>::low_pass( 0.25f64, 0.5f64), 0.45f64);
+        let gain_h = calc_gain(FilterChebyshev::<_, 3>::low_pass(0.25f64, 0.5f64), 0.45f64);
         println!("filter_iir_low_pass: 2-pole gain_h: {:.2}dB", gain_h);
         assert!(gain_h < -15.0);
 
-        let gain_l = calc_gain(FilterChebyshev::<_,3>::low_pass( 0.25f64, 0.5f64), 0.05f64);
+        let gain_l = calc_gain(FilterChebyshev::<_, 3>::low_pass(0.25f64, 0.5f64), 0.05f64);
         println!("filter_iir_low_pass: 2-pole gain_l: {:.2}dB", gain_l);
         assert!(gain_l > -0.5);
         assert!(gain_l < 0.01);
@@ -526,11 +531,11 @@ mod tests {
 
     #[test]
     fn filter_iir_low_pass_performance_4pole() {
-        let gain_h = calc_gain(FilterChebyshev::<_,5>::low_pass( 0.25f64, 0.5f64), 0.45f64);
+        let gain_h = calc_gain(FilterChebyshev::<_, 5>::low_pass(0.25f64, 0.5f64), 0.45f64);
         println!("filter_iir_low_pass: 4-pole gain_h: {:.2}dB", gain_h);
         assert!(gain_h < -35.0);
 
-        let gain_l = calc_gain(FilterChebyshev::<_,5>::low_pass( 0.25f64, 0.5f64), 0.05f64);
+        let gain_l = calc_gain(FilterChebyshev::<_, 5>::low_pass(0.25f64, 0.5f64), 0.05f64);
         println!("filter_iir_low_pass: 4-pole gain_l: {:.2}dB", gain_l);
         assert!(gain_l > -0.5);
         assert!(gain_l < 0.01);
@@ -538,11 +543,11 @@ mod tests {
 
     #[test]
     fn filter_iir_low_pass_performance_6pole() {
-        let gain_h = calc_gain(FilterChebyshev::<_,7>::low_pass( 0.25f64, 0.5f64), 0.45f64);
+        let gain_h = calc_gain(FilterChebyshev::<_, 7>::low_pass(0.25f64, 0.5f64), 0.45f64);
         println!("filter_iir_low_pass: 6-pole gain_h: {:.2}dB", gain_h);
         assert!(gain_h < -55.0);
 
-        let gain_l = calc_gain(FilterChebyshev::<_,7>::low_pass( 0.25f64, 0.5f64), 0.05f64);
+        let gain_l = calc_gain(FilterChebyshev::<_, 7>::low_pass(0.25f64, 0.5f64), 0.05f64);
         println!("filter_iir_low_pass: 6-pole gain_l: {:.2}dB", gain_l);
         assert!(gain_l > -0.5);
         assert!(gain_l < 0.01);
@@ -551,11 +556,11 @@ mod tests {
     #[test]
     //    #[ignore] // Currently failing.
     fn filter_iir_high_pass_performance_2pole() {
-        let gain_l = calc_gain(FilterChebyshev::<_,3>::high_pass( 0.25f64, 0.5f64), 0.05f64);
+        let gain_l = calc_gain(FilterChebyshev::<_, 3>::high_pass(0.25f64, 0.5f64), 0.05f64);
         println!("filter_iir_high_pass: 2-pole gain_l: {:.2}dB", gain_l);
         assert!(gain_l < -16.0);
 
-        let gain_h = calc_gain(FilterChebyshev::<_,3>::high_pass( 0.25f64, 0.5f64), 0.5f64);
+        let gain_h = calc_gain(FilterChebyshev::<_, 3>::high_pass(0.25f64, 0.5f64), 0.5f64);
         println!("filter_iir_high_pass: 2-pole gain_h: {:.2}dB", gain_h);
         assert!(gain_h > -0.5);
         assert!(gain_h < 0.01);
@@ -564,11 +569,11 @@ mod tests {
     #[test]
     //    #[ignore] // Currently failing.
     fn filter_iir_high_pass_performance_4pole() {
-        let gain_l = calc_gain(FilterChebyshev::<_,5>::high_pass( 0.25f64, 0.5f64), 0.05f64);
+        let gain_l = calc_gain(FilterChebyshev::<_, 5>::high_pass(0.25f64, 0.5f64), 0.05f64);
         println!("filter_iir_high_pass: 4-pole gain_l: {:.2}dB", gain_l);
         assert!(gain_l < -35.0);
 
-        let gain_h = calc_gain(FilterChebyshev::<_,5>::high_pass( 0.25f64, 0.5f64), 0.5f64);
+        let gain_h = calc_gain(FilterChebyshev::<_, 5>::high_pass(0.25f64, 0.5f64), 0.5f64);
         println!("filter_iir_high_pass: 4-pole gain_h: {:.2}dB", gain_h);
         assert!(gain_h > -0.5);
         assert!(gain_h < 0.01);
@@ -577,11 +582,11 @@ mod tests {
     #[test]
     //    #[ignore] // Currently failing.
     fn filter_iir_high_pass_performance_6pole() {
-        let gain_l = calc_gain(FilterChebyshev::<_,7>::high_pass( 0.25f64, 0.5f64), 0.05f64);
+        let gain_l = calc_gain(FilterChebyshev::<_, 7>::high_pass(0.25f64, 0.5f64), 0.05f64);
         println!("filter_iir_high_pass: 6-pole gain_l: {:.2}dB", gain_l);
         assert!(gain_l < -52.0);
 
-        let gain_h = calc_gain(FilterChebyshev::<_,7>::high_pass( 0.25f64, 0.5f64), 0.5f64);
+        let gain_h = calc_gain(FilterChebyshev::<_, 7>::high_pass(0.25f64, 0.5f64), 0.5f64);
         println!("filter_iir_high_pass: 6-pole gain_h: {:.2}dB", gain_h);
         assert!(gain_h > -0.5);
         assert!(gain_h < 0.01);

--- a/quick-dsp/src/filter/iir.rs
+++ b/quick-dsp/src/filter/iir.rs
@@ -23,55 +23,55 @@
 
 use super::*;
 
-fn calc_chebyshev<T: Real>(
+fn calc_chebyshev(
     poles: usize,
     p: usize,
-    cutoff1: T,
-    _cutoff2: T,
-    ripple: T,
+    cutoff1: f64,
+    _cutoff2: f64,
+    ripple: f64,
     filter_type: FilterType,
-) -> ([T; 3], [T; 3]) {
-    let theta_p = T::ONE;
+) -> ([f64; 3], [f64; 3]) {
+    let theta_p = 1.0;
 
     // Calculate the pole location on the unit circle.
     //rp = -cos(M_PI/(poles*2.0) + (p-1.0)*M_PI/poles);
     //ip = sin(M_PI/(poles*2.0) + (p-1.0)*M_PI/poles);
-    let mut rp = -(T::PI / T::from_usize(poles * 2)
-        + T::from_usize(p - 1) * T::PI / T::from_usize(poles))
+    let mut rp = -(f64::PI / f64::from_usize(poles * 2)
+        +  f64::from_usize(p - 1) * f64::PI / f64::from_usize(poles))
     .cos();
-    let mut ip = (T::PI / T::from_usize(poles * 2)
-        + T::from_usize(p - 1) * T::PI / T::from_usize(poles))
+    let mut ip = (f64::PI / f64::from_usize(poles * 2)
+        + f64::from_usize(p - 1) * f64::PI / f64::from_usize(poles))
     .sin();
 
-    let mut x = [T::ZERO, T::ZERO, T::ZERO];
-    let mut y = [-T::ONE, T::ZERO, T::ZERO];
+    let mut x = [0.0, 0.0, 0.0];
+    let mut y = [-1.0, 0.0, 0.0];
 
-    if ripple > T::from_f64(0.0001) {
+    if ripple > 0.0001 {
         // Warp from a circle into an elipse.
 
-        let unripple = (T::from_f64(100.0) / (T::from_f64(100.0) - ripple)).powi(2);
-        let es = (unripple - T::ONE).sqrt();
-        let one_over_poles = T::ONE / T::from_usize(poles);
-        let vx = one_over_poles * ((T::ONE / es) + (T::ONE / (es * es) + T::ONE).sqrt()).ln();
-        let mut kx = one_over_poles * ((T::ONE / es) + (T::ONE / (es * es) - T::ONE).sqrt()).ln();
-        kx = (T::E.powf(kx) + T::E.powf(-kx)) / T::TWO;
+        let unripple = (100.0 / (100.0 - ripple)).powi(2);
+        let es = (unripple - 1.0).sqrt();
+        let one_over_poles = 1.0 / f64::from_usize(poles);
+        let vx = one_over_poles * ((1.0 / es) + (1.0 / (es * es) + 1.0).sqrt()).ln();
+        let mut kx = one_over_poles * ((1.0 / es) + (1.0 / (es * es) - 1.0).sqrt()).ln();
+        kx = (f64::E.powf(kx) + f64::E.powf(-kx)) / 2.0;
 
-        rp *= ((T::E.powf(vx) - T::E.powf(-vx)) / T::TWO) / kx;
-        ip *= ((T::E.powf(vx) + T::E.powf(-vx)) / T::TWO) / kx;
+        rp *= ((f64::E.powf(vx) - f64::E.powf(-vx)) / 2.0) / kx;
+        ip *= ((f64::E.powf(vx) + f64::E.powf(-vx)) / 2.0) / kx;
     }
 
     {
         // S-domain to Z-domain transformation.
-        let t = T::from_f64(2.0f64 * (1.0f64 / 2.0f64).tan());
+        let t = 2.0f64 * (1.0f64 / 2.0f64).tan();
         let m = rp * rp + ip * ip;
-        let d = T::from_usize(4) - T::from_usize(4) * rp * t + m * t * t;
+        let d = 4.0 - 4.0 * rp * t + m * t * t;
 
         x[0] = t * t / d;
-        x[1] = T::TWO * x[0];
+        x[1] = 2.0 * x[0];
         x[2] = x[0];
 
-        y[1] = (T::from_usize(8) - T::TWO * m * t * t) / d;
-        y[2] = (-T::from_usize(4) - T::from_usize(4) * rp * t - m * t * t) / d;
+        y[1] = (8.0 - 2.0 * m * t * t) / d;
+        y[2] = (-4.0 - 4.0 * rp * t - m * t * t) / d;
     }
 
     if filter_type.is_band() {
@@ -90,26 +90,26 @@ fn calc_chebyshev<T: Real>(
         // }
     } else {
         // LP-to-LP or LP-to-HP transformation
-        let mu_p = T::TAU * cutoff1;
+        let mu_p = f64::TAU * cutoff1;
 
-        y[0] = -T::ONE;
+        y[0] = -1.0;
 
         let alpha = if filter_type.is_high_pass() {
-            -((theta_p + mu_p) / T::TWO).cos() / ((theta_p - mu_p) / T::TWO).cos()
+            -((theta_p + mu_p) / 2.0).cos() / ((theta_p - mu_p) / 2.0).cos()
         } else {
-            ((theta_p - mu_p) / T::TWO).sin() / ((theta_p + mu_p) / T::TWO).sin()
+            ((theta_p - mu_p) / 2.0).sin() / ((theta_p + mu_p) / 2.0).sin()
         };
 
-        let d = T::ONE + y[1] * alpha - y[2] * alpha * alpha;
+        let d = 1.0 + y[1] * alpha - y[2] * alpha * alpha;
 
-        let mut a = [T::ZERO; 3];
-        let mut b = [T::ZERO; 3];
+        let mut a = [0.0; 3];
+        let mut b = [0.0; 3];
 
         a[0] = (x[0] - x[1] * alpha + x[2] * alpha * alpha) / d;
-        a[1] = (x[1] - T::TWO * x[0] * alpha - T::TWO * x[2] * alpha + x[1] * alpha * alpha) / d;
+        a[1] = (x[1] - 2.0 * x[0] * alpha - 2.0 * x[2] * alpha + x[1] * alpha * alpha) / d;
         a[2] = (x[2] - x[1] * alpha + x[0] * alpha * alpha) / d;
 
-        b[1] = (y[1] - T::TWO * y[0] * alpha - T::TWO * y[2] * alpha + y[1] * alpha * alpha) / d;
+        b[1] = (y[1] - 2.0 * y[0] * alpha - 2.0 * y[2] * alpha + y[1] * alpha * alpha) / d;
         b[2] = (y[2] - y[1] * alpha + y[0] * alpha * alpha) / d;
 
         if filter_type.is_high_pass() {
@@ -148,61 +148,76 @@ fn adjust_gain<T: Real>(a: &mut [T], x: T) {
     }
 }
 
+pub trait FilterIirKernel {
+    type Sample: Real;
+    const A_TAPS: usize;
+    const B_TAPS: usize;
+
+    fn a(&self) -> &[Self::Sample];
+    fn b(&self) -> &[Self::Sample];
+
+    fn gain_low(&self) -> Self::Sample {
+        calc_gain_low(self.a(), self.b())
+    }
+
+    fn gain_high(&self) -> Self::Sample {
+        calc_gain_high(self.a(), self.b())
+    }
+}
+
 #[derive(Clone, Debug)]
-pub struct FilterIirKernel<T> {
-    a: Vec<T>,
-    b: Vec<T>,
+pub struct ChebyshevKernel<T, const TAPS: usize> {
+    a: [T; TAPS],
+    b: [T; TAPS],
     delay: usize,
 }
 
-impl<T: Real> Kernel for FilterIirKernel<T> {
-    type Filter = FilterIir<T>;
+impl<T, const TAPS: usize> Delay for ChebyshevKernel<T, TAPS> {
+    fn delay(&self) -> usize {
+        self.delay
+    }
+}
+
+impl<T: Real, const TAPS: usize> FilterIirKernel for ChebyshevKernel<T, TAPS> {
+    type Sample = T;
+    const A_TAPS: usize = TAPS;
+    const B_TAPS: usize = TAPS;
+
+    fn a(&self) -> &[T] {
+        self.a.as_slice()
+    }
+
+    fn b(&self) -> &[T] {
+        self.b.as_slice()
+    }
+}
+
+impl<T: Real, const TAPS: usize> IntoFilter<T> for ChebyshevKernel<T, TAPS> {
+    type Filter = FilterIir<Self>;
     fn into_filter(self) -> Self::Filter {
         FilterIir::from_kernel(self)
     }
 }
 
-impl<T: Real> FilterIirKernel<T> {
-    pub fn new(a: Vec<T>, b: Vec<T>, delay: usize) -> Self {
-        FilterIirKernel { a, b, delay }
-    }
-
-    fn gain_low(&self) -> T {
-        calc_gain_low(&self.a, &self.b)
-    }
-
-    fn gain_high(&self) -> T {
-        calc_gain_high(&self.a, &self.b)
-    }
-
+impl<T: Real, const TAPS: usize> ChebyshevKernel<T, TAPS> {
     fn adjust_gain(&mut self, gain: T) {
         adjust_gain(&mut self.a, gain)
     }
-
-    pub fn len(&self) -> usize {
-        self.a.len()
-    }
-
-    pub fn poles(&self) -> usize {
-        self.a.len() - 1
-    }
 }
 
-impl<T: Real> FilterIirKernel<T> {
+impl<T: Real, const TAPS: usize> ChebyshevKernel<T, TAPS> {
     fn chebyshev(
-        poles: usize,
-        cutoff1: T,
-        _cutoff2: T,
-        ripple: T,
+        cutoff1: f64,
+        cutoff2: f64,
+        ripple: f64,
         filter_type: FilterType,
     ) -> Self {
+        let poles = (TAPS-1) as usize;
         let mut ret = Self {
-            a: vec![],
-            b: vec![],
+            a: [T::ZERO; TAPS],
+            b: [T::ZERO; TAPS],
             delay: poles / 2,
         };
-        ret.a.resize(poles + 1, T::ZERO);
-        ret.b.resize(poles + 1, T::ZERO);
         ret.a[0] = T::ONE;
         ret.b[0] = T::ONE;
 
@@ -210,14 +225,16 @@ impl<T: Real> FilterIirKernel<T> {
             todo!();
         } else {
             for p in 1..=(poles / 2) {
-                let mut ta = ret.a.clone();
-                let mut tb = ret.b.clone();
+                let mut ta = ret.a().to_vec().clone();
+                let mut tb = ret.b().to_vec().clone();
                 ta.insert(0, T::ZERO);
                 ta.insert(0, T::ZERO);
                 tb.insert(0, T::ZERO);
                 tb.insert(0, T::ZERO);
 
-                let (a_x, b_x) = calc_chebyshev(poles, p, cutoff1, cutoff1, ripple, filter_type);
+                let (a_x, b_x) = calc_chebyshev(poles, p, cutoff1, cutoff2, ripple, filter_type);
+                let a_x = [T::from_f64(a_x[0]),T::from_f64(a_x[1]),T::from_f64(a_x[2])];
+                let b_x = [T::from_f64(b_x[0]),T::from_f64(b_x[1]),T::from_f64(b_x[2])];
                 for (i, (a, b)) in ret.a.iter_mut().zip(ret.b.iter_mut()).enumerate() {
                     *a = a_x[0] * ta[i + 2] + a_x[1] * ta[i + 1] + a_x[2] * ta[i + 0];
                     *b = tb[i + 2] - b_x[1] * tb[i + 1] - b_x[2] * tb[i + 0];
@@ -242,90 +259,93 @@ impl<T: Real> FilterIirKernel<T> {
         return ret;
     }
 
-    pub fn low_pass(poles: usize, cutoff: T, ripple: T) -> Self {
-        Self::chebyshev(poles, cutoff, T::ZERO, ripple, FilterType::LowPass)
+    pub fn low_pass(cutoff: f64, ripple: f64) -> Self {
+        Self::chebyshev(cutoff, 0.0, ripple, FilterType::LowPass)
     }
 
-    pub fn high_pass(poles: usize, cutoff: T, ripple: T) -> Self {
-        Self::chebyshev(poles, cutoff, T::ZERO, ripple, FilterType::HighPass)
+    pub fn high_pass(cutoff: f64, ripple: f64) -> Self {
+        Self::chebyshev(cutoff, 0.0, ripple, FilterType::HighPass)
     }
 
-    pub fn band_pass(poles: usize, lcutoff: T, hcutoff: T, ripple: T) -> Self {
-        Self::chebyshev(poles, lcutoff, hcutoff, ripple, FilterType::BandPass)
+    pub fn band_pass(lcutoff: f64, hcutoff: f64, ripple: f64) -> Self {
+        Self::chebyshev(lcutoff, hcutoff, ripple, FilterType::BandPass)
     }
 
-    pub fn band_stop(poles: usize, lcutoff: T, hcutoff: T, ripple: T) -> Self {
-        Self::chebyshev(poles, lcutoff, hcutoff, ripple, FilterType::BandStop)
+    pub fn band_stop(lcutoff: f64, hcutoff: f64, ripple: f64) -> Self {
+        Self::chebyshev(lcutoff, hcutoff, ripple, FilterType::BandStop)
     }
 }
 
-impl<T: Real> From<FilterIirKernel<T>> for FilterIir<T> {
-    fn from(kernel: FilterIirKernel<T>) -> Self {
+impl<T: Real, const TAPS: usize> From<ChebyshevKernel<T, TAPS>> for FilterIir<ChebyshevKernel<T, TAPS>> {
+    fn from(kernel: ChebyshevKernel<T, TAPS>) -> Self {
         FilterIir::from_kernel(kernel)
     }
 }
 
 #[derive(Clone, Debug)]
-pub struct FilterIir<T> {
-    kernel: FilterIirKernel<T>,
-    x: CircularQueue<T>,
-    y: CircularQueue<T>,
+pub struct FilterIir<K: FilterIirKernel> {
+    kernel: K,
+    x: CircularQueue<K::Sample>,
+    y: CircularQueue<K::Sample>,
 }
 
-impl<T: Real> FilterIir<T> {
-    pub fn from_kernel(kernel: FilterIirKernel<T>) -> Self {
+impl<K: FilterIirKernel> FilterIir<K> {
+    pub fn from_kernel(kernel: K) -> Self {
         FilterIir {
-            x: CircularQueue::with_capacity(kernel.len()),
-            y: CircularQueue::with_capacity(kernel.len()),
+            x: CircularQueue::with_capacity(K::A_TAPS),
+            y: CircularQueue::with_capacity(K::B_TAPS),
             kernel,
         }
     }
+}
 
-    pub fn low_pass(poles: usize, cutoff: T, ripple: T) -> Self {
-        FilterIirKernel::low_pass(poles, cutoff, ripple).into()
+impl<T: Real, const TAPS: usize> FilterIir<ChebyshevKernel<T, TAPS>> {
+    pub fn low_pass(cutoff: f64, ripple: f64) -> Self {
+        ChebyshevKernel::low_pass(cutoff, ripple).into()
     }
 
-    pub fn high_pass(poles: usize, cutoff: T, ripple: T) -> Self {
-        FilterIirKernel::high_pass(poles, cutoff, ripple).into()
+    pub fn high_pass(cutoff: f64, ripple: f64) -> Self {
+        ChebyshevKernel::high_pass(cutoff, ripple).into()
     }
 
-    pub fn band_pass(poles: usize, lcutoff: T, hcutoff: T, ripple: T) -> Self {
-        FilterIirKernel::band_pass(poles, lcutoff, hcutoff, ripple).into()
+    pub fn band_pass(lcutoff: f64, hcutoff: f64, ripple: f64) -> Self {
+        ChebyshevKernel::band_pass(lcutoff, hcutoff, ripple).into()
     }
 }
 
-impl<T: Debug> Delay for FilterIir<T> {
+impl<K: FilterIirKernel + Delay> Delay for FilterIir<K> {
     fn delay(&self) -> usize {
-        self.kernel.delay
+        self.kernel.delay()
     }
 }
 
-impl<T> OneToOne<T> for FilterIir<T>
+impl<K: FilterIirKernel> Filter<K::Sample> for FilterIir<K>
 where
-    T: Real,
+    K::Sample: Real,
 {
-    type Output = T;
-    fn filter(&mut self, sample: T) -> T {
+    type Output = K::Sample;
+    fn filter(&mut self, sample: K::Sample) -> Self::Output {
+        use num::Float;
         if !sample.is_finite() {
             return sample;
         }
 
         self.x.push(sample);
-        self.y.push(T::ZERO);
+        self.y.push(K::Sample::ZERO);
 
         let output = self
             .x
             .iter()
-            .zip(self.kernel.a.iter())
+            .zip(self.kernel.a().iter())
             .map(|(x, a)| x.mul(*a))
-            .sum::<T>()
+            .sum::<K::Sample>()
             + self
                 .y
                 .iter()
                 .skip(1)
-                .zip(self.kernel.b.iter().skip(1))
+                .zip(self.kernel.b().iter().skip(1))
                 .map(|(y, b)| y.mul(*b))
-                .sum::<T>();
+                .sum::<K::Sample>();
 
         if output.is_finite() {
             *self.y.iter_mut().next().unwrap() = output;
@@ -334,6 +354,8 @@ where
         output
     }
 }
+
+pub type FilterChebyshev<T, const TAPS: usize> = FilterIir<ChebyshevKernel<T, TAPS>>;
 
 #[cfg(test)]
 mod tests {
@@ -361,7 +383,7 @@ mod tests {
 
     #[test]
     fn filter_iir_dataset_test2() {
-        let (a, b) = calc_chebyshev(4, 2, 0.1f64, 0.0f64, 10.0f64, FilterType::HighPass);
+        let (a, b) = calc_chebyshev(4, 2, 0.1, 0.0, 10.0, FilterType::HighPass);
         println!("filter_iir_dataset_test2: a={:?}", a);
         println!("filter_iir_dataset_test2: b={:?}", b);
         assert!((a[0] - 0.922919).abs() < 0.00001);
@@ -373,24 +395,24 @@ mod tests {
 
     #[test]
     fn filter_iir_dataset_test3() {
-        let filter = FilterIir::low_pass(4, 0.25f64, 0.5f64);
+        let filter = FilterChebyshev::<f64,5>::low_pass(0.25, 0.5);
         println!("filter_iir_dataset_test3: {:#?}", filter);
 
-        assert!((filter.kernel.a[0] - 0.07015301).abs() < 0.00001);
-        assert!((filter.kernel.a[1] - 0.2806120).abs() < 0.00001);
-        assert!((filter.kernel.a[2] - 0.4209180).abs() < 0.00001);
-        assert!((filter.kernel.a[3] - 0.2806120).abs() < 0.00001);
-        assert!((filter.kernel.a[4] - 0.07015301).abs() < 0.00001);
+        assert!((filter.kernel.a()[0] - 0.07015301).abs() < 0.00001);
+        assert!((filter.kernel.a()[1] - 0.2806120).abs() < 0.00001);
+        assert!((filter.kernel.a()[2] - 0.4209180).abs() < 0.00001);
+        assert!((filter.kernel.a()[3] - 0.2806120).abs() < 0.00001);
+        assert!((filter.kernel.a()[4] - 0.07015301).abs() < 0.00001);
 
-        assert!((filter.kernel.b[1] - 0.4541481).abs() < 0.00001);
-        assert!((filter.kernel.b[2] + 0.7417536).abs() < 0.00001);
-        assert!((filter.kernel.b[3] - 0.2361222).abs() < 0.00001);
-        assert!((filter.kernel.b[4] + 0.07096476).abs() < 0.00001);
+        assert!((filter.kernel.b()[1] - 0.4541481).abs() < 0.00001);
+        assert!((filter.kernel.b()[2] + 0.7417536).abs() < 0.00001);
+        assert!((filter.kernel.b()[3] - 0.2361222).abs() < 0.00001);
+        assert!((filter.kernel.b()[4] + 0.07096476).abs() < 0.00001);
     }
 
     #[test]
     fn filter_iir_low_pass_histogram_2_pole() {
-        let kernel = FilterIirKernel::low_pass(2, 0.25f64, 0.5f64);
+        let kernel = ChebyshevKernel::<_,3>::low_pass(0.25f64, 0.5f64);
 
         let fresponse = (0..50)
             .into_iter()
@@ -407,7 +429,7 @@ mod tests {
 
     #[test]
     fn filter_iir_low_pass_histogram_4_pole() {
-        let kernel = FilterIirKernel::low_pass(4, 0.25f64, 0.5f64);
+        let kernel = ChebyshevKernel::<_,5>::low_pass(0.25f64, 0.5f64);
 
         let fresponse = (0..50)
             .into_iter()
@@ -424,7 +446,7 @@ mod tests {
 
     #[test]
     fn filter_iir_low_pass_histogram_6_pole() {
-        let kernel = FilterIirKernel::low_pass(6, 0.25f64, 0.5f64);
+        let kernel = ChebyshevKernel::<_,7>::low_pass(0.25f64, 0.5f64);
 
         let fresponse = (0..50)
             .into_iter()
@@ -441,7 +463,7 @@ mod tests {
 
     #[test]
     fn filter_iir_high_pass_histogram_2_pole() {
-        let kernel = FilterIirKernel::high_pass(2, 0.25f64, 0.5f64);
+        let kernel = ChebyshevKernel::<_,3>::high_pass(0.25f64, 0.5f64);
 
         let fresponse = (1..=50)
             .into_iter()
@@ -458,7 +480,7 @@ mod tests {
 
     #[test]
     fn filter_iir_high_pass_histogram_4_pole() {
-        let kernel = FilterIirKernel::high_pass(4, 0.25f64, 0.5f64);
+        let kernel = ChebyshevKernel::<_,5>::high_pass(0.25f64, 0.5f64);
 
         let fresponse = (1..=50)
             .into_iter()
@@ -475,7 +497,7 @@ mod tests {
 
     #[test]
     fn filter_iir_high_pass_histogram_6_pole() {
-        let kernel = FilterIirKernel::high_pass(6, 0.25f64, 0.5f64);
+        let kernel = ChebyshevKernel::<_,7>::high_pass(0.25f64, 0.5f64);
 
         let fresponse = (1..=50)
             .into_iter()
@@ -492,11 +514,11 @@ mod tests {
 
     #[test]
     fn filter_iir_low_pass_performance_2pole() {
-        let gain_h = calc_gain(FilterIir::low_pass(2, 0.25f64, 0.5f64), 0.45f64);
+        let gain_h = calc_gain(FilterChebyshev::<_,3>::low_pass( 0.25f64, 0.5f64), 0.45f64);
         println!("filter_iir_low_pass: 2-pole gain_h: {:.2}dB", gain_h);
         assert!(gain_h < -15.0);
 
-        let gain_l = calc_gain(FilterIir::low_pass(2, 0.25f64, 0.5f64), 0.05f64);
+        let gain_l = calc_gain(FilterChebyshev::<_,3>::low_pass( 0.25f64, 0.5f64), 0.05f64);
         println!("filter_iir_low_pass: 2-pole gain_l: {:.2}dB", gain_l);
         assert!(gain_l > -0.5);
         assert!(gain_l < 0.01);
@@ -504,11 +526,11 @@ mod tests {
 
     #[test]
     fn filter_iir_low_pass_performance_4pole() {
-        let gain_h = calc_gain(FilterIir::low_pass(4, 0.25f64, 0.5f64), 0.45f64);
+        let gain_h = calc_gain(FilterChebyshev::<_,5>::low_pass( 0.25f64, 0.5f64), 0.45f64);
         println!("filter_iir_low_pass: 4-pole gain_h: {:.2}dB", gain_h);
         assert!(gain_h < -35.0);
 
-        let gain_l = calc_gain(FilterIir::low_pass(4, 0.25f64, 0.5f64), 0.05f64);
+        let gain_l = calc_gain(FilterChebyshev::<_,5>::low_pass( 0.25f64, 0.5f64), 0.05f64);
         println!("filter_iir_low_pass: 4-pole gain_l: {:.2}dB", gain_l);
         assert!(gain_l > -0.5);
         assert!(gain_l < 0.01);
@@ -516,11 +538,11 @@ mod tests {
 
     #[test]
     fn filter_iir_low_pass_performance_6pole() {
-        let gain_h = calc_gain(FilterIir::low_pass(6, 0.25f64, 0.5f64), 0.45f64);
+        let gain_h = calc_gain(FilterChebyshev::<_,7>::low_pass( 0.25f64, 0.5f64), 0.45f64);
         println!("filter_iir_low_pass: 6-pole gain_h: {:.2}dB", gain_h);
         assert!(gain_h < -55.0);
 
-        let gain_l = calc_gain(FilterIir::low_pass(6, 0.25f64, 0.5f64), 0.05f64);
+        let gain_l = calc_gain(FilterChebyshev::<_,7>::low_pass( 0.25f64, 0.5f64), 0.05f64);
         println!("filter_iir_low_pass: 6-pole gain_l: {:.2}dB", gain_l);
         assert!(gain_l > -0.5);
         assert!(gain_l < 0.01);
@@ -529,11 +551,11 @@ mod tests {
     #[test]
     //    #[ignore] // Currently failing.
     fn filter_iir_high_pass_performance_2pole() {
-        let gain_l = calc_gain(FilterIir::high_pass(2, 0.25f64, 0.5f64), 0.05f64);
+        let gain_l = calc_gain(FilterChebyshev::<_,3>::high_pass( 0.25f64, 0.5f64), 0.05f64);
         println!("filter_iir_high_pass: 2-pole gain_l: {:.2}dB", gain_l);
         assert!(gain_l < -16.0);
 
-        let gain_h = calc_gain(FilterIir::high_pass(2, 0.25f64, 0.5f64), 0.5f64);
+        let gain_h = calc_gain(FilterChebyshev::<_,3>::high_pass( 0.25f64, 0.5f64), 0.5f64);
         println!("filter_iir_high_pass: 2-pole gain_h: {:.2}dB", gain_h);
         assert!(gain_h > -0.5);
         assert!(gain_h < 0.01);
@@ -542,11 +564,11 @@ mod tests {
     #[test]
     //    #[ignore] // Currently failing.
     fn filter_iir_high_pass_performance_4pole() {
-        let gain_l = calc_gain(FilterIir::high_pass(4, 0.25f64, 0.5f64), 0.05f64);
+        let gain_l = calc_gain(FilterChebyshev::<_,5>::high_pass( 0.25f64, 0.5f64), 0.05f64);
         println!("filter_iir_high_pass: 4-pole gain_l: {:.2}dB", gain_l);
         assert!(gain_l < -35.0);
 
-        let gain_h = calc_gain(FilterIir::high_pass(4, 0.25f64, 0.5f64), 0.5f64);
+        let gain_h = calc_gain(FilterChebyshev::<_,5>::high_pass( 0.25f64, 0.5f64), 0.5f64);
         println!("filter_iir_high_pass: 4-pole gain_h: {:.2}dB", gain_h);
         assert!(gain_h > -0.5);
         assert!(gain_h < 0.01);
@@ -555,11 +577,11 @@ mod tests {
     #[test]
     //    #[ignore] // Currently failing.
     fn filter_iir_high_pass_performance_6pole() {
-        let gain_l = calc_gain(FilterIir::high_pass(6, 0.25f64, 0.5f64), 0.05f64);
+        let gain_l = calc_gain(FilterChebyshev::<_,7>::high_pass( 0.25f64, 0.5f64), 0.05f64);
         println!("filter_iir_high_pass: 6-pole gain_l: {:.2}dB", gain_l);
         assert!(gain_l < -52.0);
 
-        let gain_h = calc_gain(FilterIir::high_pass(6, 0.25f64, 0.5f64), 0.5f64);
+        let gain_h = calc_gain(FilterChebyshev::<_,7>::high_pass( 0.25f64, 0.5f64), 0.5f64);
         println!("filter_iir_high_pass: 6-pole gain_h: {:.2}dB", gain_h);
         assert!(gain_h > -0.5);
         assert!(gain_h < 0.01);

--- a/quick-dsp/src/filter/iter.rs
+++ b/quick-dsp/src/filter/iter.rs
@@ -19,7 +19,7 @@
 // TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-use crate::filter::{HdlcEncoderIter, NrziEncode, Filter, ResampleNN};
+use crate::filter::{Filter, HdlcEncoderIter, NrziEncode, ResampleNN};
 
 /// Transforms an iterator over bytes into an iterator over bits,
 /// most significant bit first.

--- a/quick-dsp/src/filter/iter.rs
+++ b/quick-dsp/src/filter/iter.rs
@@ -19,7 +19,7 @@
 // TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-use crate::filter::{HdlcEncoderIter, NrziEncode, OneToOne, ResampleNN};
+use crate::filter::{HdlcEncoderIter, NrziEncode, Filter, ResampleNN};
 
 /// Transforms an iterator over bytes into an iterator over bits,
 /// most significant bit first.
@@ -68,7 +68,7 @@ pub struct OneToOneIter<T, F> {
     filter: F,
 }
 
-impl<T: Iterator, F: OneToOne<T::Item>> Iterator for OneToOneIter<T, F> {
+impl<T: Iterator, F: Filter<T::Item>> Iterator for OneToOneIter<T, F> {
     type Item = F::Output;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -178,7 +178,7 @@ pub trait IteratorExt: Iterator {
 
     fn apply_one_to_one<F>(self, filter: F) -> OneToOneIter<Self, F>
     where
-        F: OneToOne<Self::Item>,
+        F: Filter<Self::Item>,
         Self: std::marker::Sized + Iterator,
     {
         OneToOneIter { iter: self, filter }

--- a/quick-dsp/src/filter/mod.rs
+++ b/quick-dsp/src/filter/mod.rs
@@ -34,8 +34,8 @@ mod hdlc;
 mod iir;
 mod iter;
 mod nrzi;
-mod resample;
 mod qam;
+mod resample;
 
 pub use boxfilter::*;
 pub use decimator::*;
@@ -47,8 +47,8 @@ pub use hdlc::*;
 pub use iir::*;
 pub use iter::*;
 pub use nrzi::*;
-pub use resample::*;
 pub use qam::*;
+pub use resample::*;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum Window {
@@ -63,34 +63,34 @@ pub enum Window {
 }
 
 pub trait WindowFunc {
-    fn window_func(&self, t: f64, l:f64) -> f64;
+    fn window_func(&self, t: f64, l: f64) -> f64;
 }
 
 impl WindowFunc for Window {
     fn window_func(&self, t: f64, l: f64) -> f64 {
         match self {
             Window::Rectangular => 1.0,
-            Window::Bartlett => 2.0*((l/2.0)+t.abs())/l,
-            Window::Hann => 0.5 - 0.5 * f64::cos((f64::PI*2.0 * t) / l),
-            Window::Hamming => 0.54 - 0.46 * f64::cos((f64::PI*2.0 * t) / l),
+            Window::Bartlett => 2.0 * ((l / 2.0) + t.abs()) / l,
+            Window::Hann => 0.5 - 0.5 * f64::cos((f64::PI * 2.0 * t) / l),
+            Window::Hamming => 0.54 - 0.46 * f64::cos((f64::PI * 2.0 * t) / l),
             Window::Blackman => {
-                0.42 - 0.5 * f64::cos((f64::PI*2.0 * t) / l)
-                    + 0.08 * f64::cos((f64::PI*4.0 * t) / l)
+                0.42 - 0.5 * f64::cos((f64::PI * 2.0 * t) / l)
+                    + 0.08 * f64::cos((f64::PI * 4.0 * t) / l)
             }
             Window::Nuttall => {
-                0.355768 - 0.487396 * f64::cos((f64::PI*2.0 * t) / l)
-                    + 0.144232 * f64::cos((f64::PI*4.0 * t) / l)
-                    - 0.012604 * f64::cos((f64::PI*6.0 * t) / l)
+                0.355768 - 0.487396 * f64::cos((f64::PI * 2.0 * t) / l)
+                    + 0.144232 * f64::cos((f64::PI * 4.0 * t) / l)
+                    - 0.012604 * f64::cos((f64::PI * 6.0 * t) / l)
             }
             Window::BlackmanNuttall => {
-                0.3635819 - 0.4891775 * f64::cos((f64::PI*2.0 * t) / l)
-                    + 0.1365995 * f64::cos((f64::PI*4.0 * t) / l)
-                    - 0.0106411 * f64::cos((f64::PI*6.0 * t) / l)
+                0.3635819 - 0.4891775 * f64::cos((f64::PI * 2.0 * t) / l)
+                    + 0.1365995 * f64::cos((f64::PI * 4.0 * t) / l)
+                    - 0.0106411 * f64::cos((f64::PI * 6.0 * t) / l)
             }
             Window::BlackmanHarris => {
-                0.35875 - 0.48829 * f64::cos((f64::PI*2.0 * t) / l)
-                    + 0.14128 * f64::cos((f64::PI*4.0 * t) / l)
-                    - 0.01168 * f64::cos((f64::PI*6.0 * t) / l)
+                0.35875 - 0.48829 * f64::cos((f64::PI * 2.0 * t) / l)
+                    + 0.14128 * f64::cos((f64::PI * 4.0 * t) / l)
+                    - 0.01168 * f64::cos((f64::PI * 6.0 * t) / l)
             }
         }
     }
@@ -169,11 +169,11 @@ pub trait FilterExt<T>: Filter<T> + Sized {
 }
 impl<T: Filter<A>, A> FilterExt<A> for T {}
 
-pub type BoxedFilter<'a, In, Out=In> = Box<dyn Filter<In, Output = Out> + 'a>;
+pub type BoxedFilter<'a, In, Out = In> = Box<dyn Filter<In, Output = Out> + 'a>;
 
-impl<F,T> Filter<T> for Box<F>
+impl<F, T> Filter<T> for Box<F>
 where
-    F: Filter<T>
+    F: Filter<T>,
 {
     type Output = F::Output;
 
@@ -182,8 +182,7 @@ where
     }
 }
 
-impl<F:Delay> Delay for Box<F>
-{
+impl<F: Delay> Delay for Box<F> {
     fn delay(&self) -> usize {
         self.as_ref().delay()
     }

--- a/quick-dsp/src/filter/nrzi.rs
+++ b/quick-dsp/src/filter/nrzi.rs
@@ -37,7 +37,7 @@ impl NrziEncode {
     }
 }
 
-impl OneToOne<bool> for NrziEncode {
+impl Filter<bool> for NrziEncode {
     type Output = bool;
 
     fn filter(&mut self, sample: bool) -> Self::Output {
@@ -65,7 +65,7 @@ impl NrziDecode {
     }
 }
 
-impl OneToOne<bool> for NrziDecode {
+impl Filter<bool> for NrziDecode {
     type Output = bool;
 
     fn filter(&mut self, sample: bool) -> Self::Output {
@@ -92,7 +92,7 @@ mod tests {
     fn nrzi_pipe() {
         let encode = NrziEncode::new();
         let decode = NrziDecode::new();
-        let mut chained = OneToOneExt::<bool>::chain(encode, decode);
+        let mut chained = FilterExt::<bool>::chain(encode, decode);
 
         assert_eq!(chained.filter(true), true);
         assert_eq!(chained.filter(false), false);

--- a/quick-dsp/src/filter/qam.rs
+++ b/quick-dsp/src/filter/qam.rs
@@ -1,0 +1,95 @@
+// Copyright (c) 2022, The ARNGLL-Rust Authors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+use std::marker::PhantomData;
+use super::*;
+
+/// QAM Splitter.
+///
+/// Carrier is fixed at 0.25 (freq/4)
+///
+/// Output is (i, q)
+#[derive(Clone, Debug)]
+pub struct QamSplitFixed<T, F=()> {
+    current_step: u8,
+    filter_i: F,
+    filter_q: F,
+    _t: PhantomData<T>,
+}
+
+impl<T, F: Delay> Delay for QamSplitFixed<T, F> {
+    fn delay(&self) -> usize {
+        (self.filter_i.delay() + self.filter_q.delay()) / 2
+    }
+}
+
+impl<T: Real, F> QamSplitFixed<T, F> {
+    pub fn digital_default() -> QamSplitFixed<T, FilterFir<T>> {
+        Self::new(
+            FilterFirKernel::<T>::low_pass(15, 0.1, Window::Blackman).into_filter(),
+        )
+    }
+
+    pub fn analog_default() -> QamSplitFixed<T, FilterFir<T>> {
+        Self::new(
+            FilterFirKernel::<T>::low_pass(21, 0.25, Window::Blackman).into_filter(),
+        )
+    }
+
+    pub fn new<K: Filter<T> + Clone>(
+        kiq: K
+    ) -> QamSplitFixed<T, K> {
+        QamSplitFixed {
+            current_step: 0,
+            filter_i: kiq.clone(),
+            filter_q: kiq,
+            _t: Default::default(),
+        }
+    }
+}
+
+impl<T, F: Filter<T, Output = T>> Filter<T> for QamSplitFixed<T, F>
+where
+    T: Real,
+{
+    type Output = (T, T); // (i,q)
+
+    fn filter(&mut self, sample: T) -> Self::Output {
+        if !sample.is_finite() {
+            return (T::NAN, T::NAN);
+        }
+
+        let (v_i, v_q) = match self.current_step & 3 {
+            0 => (sample, T::ZERO),
+            1 => (T::ZERO, sample),
+            2 => (-sample, T::ZERO),
+            _ => (T::ZERO, -sample),
+        };
+        self.current_step = self.current_step.wrapping_add(1);
+
+        (self.filter_i.filter(v_i), self.filter_q.filter(v_q))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //use super::*;
+}

--- a/quick-dsp/src/filter/qam.rs
+++ b/quick-dsp/src/filter/qam.rs
@@ -19,8 +19,8 @@
 // TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-use std::marker::PhantomData;
 use super::*;
+use std::marker::PhantomData;
 
 /// QAM Splitter.
 ///
@@ -28,7 +28,7 @@ use super::*;
 ///
 /// Output is (i, q)
 #[derive(Clone, Debug)]
-pub struct QamSplitFixed<T, F=()> {
+pub struct QamSplitFixed<T, F = ()> {
     current_step: u8,
     filter_i: F,
     filter_q: F,
@@ -43,20 +43,14 @@ impl<T, F: Delay> Delay for QamSplitFixed<T, F> {
 
 impl<T: Real, F> QamSplitFixed<T, F> {
     pub fn digital_default() -> QamSplitFixed<T, FilterFir<T>> {
-        Self::new(
-            FilterFirKernel::<T>::low_pass(15, 0.1, Window::Blackman).into_filter(),
-        )
+        Self::new(FilterFirKernel::<T>::low_pass(15, 0.1, Window::Blackman).into_filter())
     }
 
     pub fn analog_default() -> QamSplitFixed<T, FilterFir<T>> {
-        Self::new(
-            FilterFirKernel::<T>::low_pass(21, 0.25, Window::Blackman).into_filter(),
-        )
+        Self::new(FilterFirKernel::<T>::low_pass(21, 0.25, Window::Blackman).into_filter())
     }
 
-    pub fn new<K: Filter<T> + Clone>(
-        kiq: K
-    ) -> QamSplitFixed<T, K> {
+    pub fn new<K: Filter<T> + Clone>(kiq: K) -> QamSplitFixed<T, K> {
         QamSplitFixed {
             current_step: 0,
             filter_i: kiq.clone(),

--- a/quick-dsp/src/filter/resample.rs
+++ b/quick-dsp/src/filter/resample.rs
@@ -65,7 +65,7 @@ impl<T: Real> Downsampler<T> {
     }
 }
 
-impl<T: Real> OneToOne<T> for Downsampler<T> {
+impl<T: Real> Filter<T> for Downsampler<T> {
     type Output = Option<T>;
 
     fn filter(&mut self, mut sample: T) -> Self::Output {

--- a/quick-dsp/tests/bell_202.rs
+++ b/quick-dsp/tests/bell_202.rs
@@ -68,7 +68,9 @@ fn run_benchmark<P: AsRef<Path>>(path: P) -> u32 {
                     }
 
                     if X25.checksum(&frame) != 0x0f47 {
-                        badframecount += 1;
+                        if Ax25Debug(&frame).is_ax25() {
+                            badframecount += 1;
+                        }
                     } else {
                         framecount += 1;
                     }
@@ -78,10 +80,11 @@ fn run_benchmark<P: AsRef<Path>>(path: P) -> u32 {
         _ => panic!("bad data"),
     }
     println!(
-        "{}: Success:{} Bad-CRC:{}",
+        "{}: Success:{} Bad-CRC:{}, Total:{}",
         path.as_ref().to_str().unwrap(),
         framecount,
-        badframecount
+        badframecount,
+        framecount+badframecount
     );
     framecount
 }
@@ -99,7 +102,7 @@ fn benchmark_testcd01() {
         eprintln!("File {:?} doesn't exist, skipping test.", path);
         return;
     }
-    assert!(run_benchmark(path) >= 960);
+    assert!(run_benchmark(path) >= 950);
 }
 
 #[test]

--- a/quick-dsp/tests/bell_202.rs
+++ b/quick-dsp/tests/bell_202.rs
@@ -84,7 +84,7 @@ fn run_benchmark<P: AsRef<Path>>(path: P) -> u32 {
         path.as_ref().to_str().unwrap(),
         framecount,
         badframecount,
-        framecount+badframecount
+        framecount + badframecount
     );
     framecount
 }


### PR DESCRIPTION
* Updated hamaddr crate to support the new 9-char EUI-48 spec.
* Improvements when running on Linux/Raspberry-Pi
* Renamed `OnetoOne` to `Filter`.
* Bell 202 Sender now has the ability to do CCA.
* Added `FilterMedian`.
* Added a new `QamSplitFixed` filter.
* Refactored discriminator to use `QamSplitFixed`.
* Added several new window types.
* The kernel for IIR filters now has no allocations.
* Various other minor fixes and tweaks.
* Ran `cargo fmt`.